### PR TITLE
Allow networking for the IDE

### DIFF
--- a/org.processing.processingide.json
+++ b/org.processing.processingide.json
@@ -14,7 +14,8 @@
         "--socket=x11",
         "--share=ipc",
         "--device=all",
-        "--filesystem=home"
+        "--filesystem=home",
+        "--share=network"
     ],
     "cleanup": [
         "/include",


### PR DESCRIPTION
Processing allows installing libraries in order to use them with sketches. Libraries get installed in the `libraries` folder of your Processing user folder (where projects, and thus libraries, live). Without access to networking, the embedded library "one-click install" feature doesn't work.

This will also enable Processing to check for update and ask the user to redirect them to the Processing download page - which can be disabled but can also be considered a regression.