### PR TITLE
Update to version 3.5.4

### DIFF
--- a/org.processing.processingide.json
+++ b/org.processing.processingide.json
@@ -1,5 +1,4 @@
 {
-    "$schema": "https://raw.githubusercontent.com/TingPing/flatpak-manifest-schema/master/flatpak-manifest.schema",
     "app-id": "org.processing.processingide",
     "runtime": "org.freedesktop.Platform",
     "runtime-version": "19.08",

--- a/org.processing.processingide.json
+++ b/org.processing.processingide.json
@@ -1,6 +1,7 @@
 {
     "app-id": "org.processing.processingide",
     "runtime": "org.freedesktop.Platform",
+    "version": "3.5.3",
     "runtime-version": "1.6",
     "sdk": "org.freedesktop.Sdk",
     "build-options": {
@@ -40,17 +41,17 @@
                 {
                     "only-arches": ["x86_64"],
                     "type": "extra-data",
-                    "url": "https://github.com/processing/processing/releases/download/processing-0265-3.4/processing-3.4-linux64.tgz",
-                    "sha256": "62a454252f7d291da3263155e286601776ddf4790eda8b8662bac34a855e5c8e",
-                    "size": 132458798,
+                    "url": "https://github.com/processing/processing/releases/download/processing-0269-3.5.3/processing-3.5.3-linux64.tgz",
+                    "sha256": "3d52aaa898fcde52e3bcb976c06f2b8b56a60209532c1720229da9eb0cd175fa",
+                    "size": 138126131,
                     "filename": "processing.tgz"
                 },
                 {
                     "only-arches": ["arm"],
                     "type": "extra-data",
-                    "url": "https://github.com/processing/processing/releases/download/processing-0265-3.4/processing-3.4-linux-armv6hf.tgz",
-                    "sha256": "f37ecf18ff50cc69363bb1efe28d8e95b9fb8df5cdccb1b037934c6b83e956fd",
-                    "size": 100380116,
+                    "url": "https://github.com/processing/processing/releases/download/processing-0269-3.5.3/processing-3.5.3-linux-armv6hf.tgz",
+                    "sha256": "cbb1e9af16af057c7b0dd0ba2c6d447621250145d96da26cbb66b7c128d87d94",
+                    "size": 100144409,
                     "filename": "processing.tgz"
                 },
                 {

--- a/org.processing.processingide.json
+++ b/org.processing.processingide.json
@@ -14,7 +14,8 @@
         "--socket=x11",
         "--share=ipc",
         "--device=all",
-        "--filesystem=home"
+        "--filesystem=home",
+        "--share=network"
     ],
     "cleanup": [
         "/include",

--- a/org.processing.processingide.json
+++ b/org.processing.processingide.json
@@ -1,7 +1,6 @@
 {
     "app-id": "org.processing.processingide",
     "runtime": "org.freedesktop.Platform",
-    "version": "3.5.3",
     "runtime-version": "1.6",
     "sdk": "org.freedesktop.Sdk",
     "build-options": {

--- a/org.processing.processingide.json
+++ b/org.processing.processingide.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://raw.githubusercontent.com/TingPing/flatpak-manifest-schema/master/flatpak-manifest.schema",
     "app-id": "org.processing.processingide",
     "runtime": "org.freedesktop.Platform",
     "runtime-version": "18.08",
@@ -29,29 +30,20 @@
             "name": "processing",
             "buildsystem": "simple",
             "build-commands": [
-                "install -D apply_extra /app/bin/apply_extra",
                 "install -D processing /app/bin/processing",
                 "install -D appdata.xml /app/share/metainfo/org.processing.processingide.appdata.xml",
                 "install -D desktop.template /app/share/applications/org.processing.processingide.desktop",
                 "install -D processing-pde.xml /app/share/mime/packages/org.processing.processingide.xml",
                 "install -D pde-64.png /app/share/icons/hicolor/64x64/apps/org.processing.processingide.png",
-                "install -D pde-128.png /app/share/icons/hicolor/128x128/apps/org.processing.processingide.png"
+                "install -D pde-128.png /app/share/icons/hicolor/128x128/apps/org.processing.processingide.png",
+                "bash ./apply_extra"
             ],
             "sources": [
                 {
-                    "only-arches": ["x86_64"],
                     "type": "extra-data",
-                    "url": "https://github.com/processing/processing/releases/download/processing-0269-3.5.3/processing-3.5.3-linux64.tgz",
-                    "sha256": "3d52aaa898fcde52e3bcb976c06f2b8b56a60209532c1720229da9eb0cd175fa",
-                    "size": 138126131,
-                    "filename": "processing.tgz"
-                },
-                {
-                    "only-arches": ["arm"],
-                    "type": "extra-data",
-                    "url": "https://github.com/processing/processing/releases/download/processing-0269-3.5.3/processing-3.5.3-linux-armv6hf.tgz",
-                    "sha256": "cbb1e9af16af057c7b0dd0ba2c6d447621250145d96da26cbb66b7c128d87d94",
-                    "size": 100144409,
+                    "url": "https://github.com/processing/processing/releases/download/processing-0270-3.5.4/processing-3.5.4-linux64.tgz",
+                    "sha256": "ded445069db3c6fc384fe4da89ca7aa7d0a4bd2536c5aa8de3fa4e115de3025b",
+                    "size": 138144543,
                     "filename": "processing.tgz"
                 },
                 {

--- a/org.processing.processingide.json
+++ b/org.processing.processingide.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.processing.processingide",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "1.6",
+    "runtime-version": "18.08",
     "sdk": "org.freedesktop.Sdk",
     "build-options": {
         "cflags": "-O2 -g",

--- a/org.processing.processingide.json
+++ b/org.processing.processingide.json
@@ -36,51 +36,32 @@
                 "install -D processing-pde.xml /app/share/mime/packages/org.processing.processingide.xml",
                 "install -D pde-64.png /app/share/icons/hicolor/64x64/apps/org.processing.processingide.png",
                 "install -D pde-128.png /app/share/icons/hicolor/128x128/apps/org.processing.processingide.png",
-                "bash ./apply_extra"
+                "install -D lib/desktop.template export/share/applications/org.processing.processingide.desktop",
+                "sed -i -e 's|<BINARY_LOCATION>|processing|' -e 's|<ICON_NAME>|org.processing.processingide|' export/share/applications/org.processing.processingide.desktop",
+                "sed -i -e 's|Programming;||' export/share/applications/org.processing.processingide.desktop",
+                "install -D lib/icons/pde-16.png export/share/icons/hicolor/16x16/apps/org.processing.processingide.png",
+                "install -D lib/icons/pde-16.png export/share/icons/hicolor/16x16/mimetypes/org.processing.processingide-text-x-processing.png",
+                "install -D lib/icons/pde-32.png export/share/icons/hicolor/32x32/apps/org.processing.processingide.png",
+                "install -D lib/icons/pde-32.png export/share/icons/hicolor/32x32/mimetypes/org.processing.processingide-text-x-processing.png",
+                "install -D lib/icons/pde-48.png export/share/icons/hicolor/48x48/apps/org.processing.processingide.png",
+                "install -D lib/icons/pde-48.png export/share/icons/hicolor/48x48/mimetypes/org.processing.processingide-text-x-processing.png",
+                "install -D lib/icons/pde-64.png export/share/icons/hicolor/64x64/apps/org.processing.processingide.png",
+                "install -D lib/icons/pde-64.png export/share/icons/hicolor/64x64/mimetypes/org.processing.processingide-text-x-processing.png",
+                "install -D lib/icons/pde-128.png export/share/icons/hicolor/128x128/apps/org.processing.processingide.png",
+                "install -D lib/icons/pde-128.png export/share/icons/hicolor/128x128/mimetypes/org.processing.processingide-text-x-processing.png",
+                "install -D lib/icons/pde-256.png export/share/icons/hicolor/256x256/apps/org.processing.processingide.png",
+                "install -D lib/icons/pde-256.png export/share/icons/hicolor/256x256/mimetypes/org.processing.processingide-text-x-processing.png",
+                "install -D lib/icons/pde-512.png export/share/icons/hicolor/512x512/apps/org.processing.processingide.png",
+                "install -D lib/icons/pde-512.png export/share/icons/hicolor/512x512/mimetypes/org.processing.processingide-text-x-processing.png",
+                "install -D lib/icons/pde-1024.png export/share/icons/hicolor/1024x1024/apps/org.processing.processingide.png",
+                "install -D lib/icons/pde-1024.png export/share/icons/hicolor/1024x1024/mimetypes/org.processing.processingide-text-x-processing.png"
             ],
             "sources": [
                 {
-                    "type": "extra-data",
+                    "type": "archive",
                     "url": "https://github.com/processing/processing/releases/download/processing-0270-3.5.4/processing-3.5.4-linux64.tgz",
                     "sha256": "ded445069db3c6fc384fe4da89ca7aa7d0a4bd2536c5aa8de3fa4e115de3025b",
-                    "size": 138144543,
-                    "filename": "processing.tgz"
-                },
-                {
-                    "type": "script",
-                    "dest-filename": "apply_extra",
-                    "commands": [
-                        "tar -xf processing.tgz",
-                        "rm processing.tgz",
-                        "mv processing-3.4/* .",
-                        "rm -r processing-3.4",
-                        "install -D lib/desktop.template export/share/applications/org.processing.processingide.desktop",
-                        "sed -i -e 's|<BINARY_LOCATION>|processing|' -e 's|<ICON_NAME>|org.processing.processingide|' export/share/applications/org.processing.processingide.desktop",
-                        "sed -i -e 's|Programming;||' export/share/applications/org.processing.processingide.desktop",
-                        "install -D lib/icons/pde-16.png export/share/icons/hicolor/16x16/apps/org.processing.processingide.png",
-                        "install -D lib/icons/pde-16.png export/share/icons/hicolor/16x16/mimetypes/org.processing.processingide-text-x-processing.png",
-                        "install -D lib/icons/pde-32.png export/share/icons/hicolor/32x32/apps/org.processing.processingide.png",
-                        "install -D lib/icons/pde-32.png export/share/icons/hicolor/32x32/mimetypes/org.processing.processingide-text-x-processing.png",
-                        "install -D lib/icons/pde-48.png export/share/icons/hicolor/48x48/apps/org.processing.processingide.png",
-                        "install -D lib/icons/pde-48.png export/share/icons/hicolor/48x48/mimetypes/org.processing.processingide-text-x-processing.png",
-                        "install -D lib/icons/pde-64.png export/share/icons/hicolor/64x64/apps/org.processing.processingide.png",
-                        "install -D lib/icons/pde-64.png export/share/icons/hicolor/64x64/mimetypes/org.processing.processingide-text-x-processing.png",
-                        "install -D lib/icons/pde-128.png export/share/icons/hicolor/128x128/apps/org.processing.processingide.png",
-                        "install -D lib/icons/pde-128.png export/share/icons/hicolor/128x128/mimetypes/org.processing.processingide-text-x-processing.png",
-                        "install -D lib/icons/pde-256.png export/share/icons/hicolor/256x256/apps/org.processing.processingide.png",
-                        "install -D lib/icons/pde-256.png export/share/icons/hicolor/256x256/mimetypes/org.processing.processingide-text-x-processing.png",
-                        "install -D lib/icons/pde-512.png export/share/icons/hicolor/512x512/apps/org.processing.processingide.png",
-                        "install -D lib/icons/pde-512.png export/share/icons/hicolor/512x512/mimetypes/org.processing.processingide-text-x-processing.png",
-                        "install -D lib/icons/pde-1024.png export/share/icons/hicolor/1024x1024/apps/org.processing.processingide.png",
-                        "install -D lib/icons/pde-1024.png export/share/icons/hicolor/1024x1024/mimetypes/org.processing.processingide-text-x-processing.png"
-                    ]
-                },
-                {
-                    "type": "script",
-                    "dest-filename": "processing",
-                    "commands": [
-                        "exec /app/extra/processing $@"
-                    ]
+                    "size": 138144543
                 },
                 {
                     "type": "file",

--- a/org.processing.processingide.json
+++ b/org.processing.processingide.json
@@ -2,7 +2,7 @@
     "$schema": "https://raw.githubusercontent.com/TingPing/flatpak-manifest-schema/master/flatpak-manifest.schema",
     "app-id": "org.processing.processingide",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "18.08",
+    "runtime-version": "19.08",
     "sdk": "org.freedesktop.Sdk",
     "build-options": {
         "cflags": "-O2 -g",

--- a/org.processing.processingide.json
+++ b/org.processing.processingide.json
@@ -30,7 +30,9 @@
             "name": "processing",
             "buildsystem": "simple",
             "build-commands": [
-                "install -D processing /app/bin/processing",
+                "install -d /app/share/processing",
+                "cp -r * /app/share/processing",
+                "install -D processing.sh /app/bin/processing",
                 "install -D appdata.xml /app/share/metainfo/org.processing.processingide.appdata.xml",
                 "install -D desktop.template /app/share/applications/org.processing.processingide.desktop",
                 "install -D processing-pde.xml /app/share/mime/packages/org.processing.processingide.xml",
@@ -65,8 +67,8 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/processing/processing/processing-0265-3.4/build/linux/appdata.xml",
-                    "sha256": "5dba86675af37ba9f7833ad6c862679da7e958187593c329f6141a47c2d5e4e6"
+                    "url": "https://raw.githubusercontent.com/processing/processing/processing-0270-3.5.4/build/linux/appdata.xml",
+                    "sha256": "e6a142a75dece42fdee52cba1f9258f866bc95bc6318f04e92a92e1a301cac39"
                 },
                 {
                     "type": "patch",
@@ -75,7 +77,7 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/processing/processing/processing-0265-3.4/build/linux/processing-pde.xml",
+                    "url": "https://raw.githubusercontent.com/processing/processing/processing-0270-3.5.4/build/linux/processing-pde.xml",
                     "sha256": "79e70baa8c1d81a60ac1bc59ea642bf80c638e5cb0ec7fe8372503bb8f2baa7f"
                 },
                 {
@@ -85,7 +87,7 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/processing/processing/processing-0265-3.4/build/linux/desktop.template",
+                    "url": "https://raw.githubusercontent.com/processing/processing/processing-0270-3.5.4/build/linux/desktop.template",
                     "sha256": "8a241bd3c41c52fb7a7ea4a67aa2657767e9c9e8a612dd5bca62866becdf873b"
                 },
                 {
@@ -95,13 +97,21 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/processing/processing/processing-0265-3.4/build/shared/lib/icons/pde-64.png",
+                    "url": "https://raw.githubusercontent.com/processing/processing/processing-0270-3.5.4/build/shared/lib/icons/pde-64.png",
                     "sha256": "feec5cf9be795d274296f39796b15994763f335be01c524b6216cf03de0a1b99"
                 },
                 {
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/processing/processing/processing-0265-3.4/build/shared/lib/icons/pde-128.png",
+                    "url": "https://raw.githubusercontent.com/processing/processing/processing-0270-3.5.4/build/shared/lib/icons/pde-128.png",
                     "sha256": "1ee11856d783a44a5d4464206ae98d856dee837b9dc94ec5b06a4ca3b6f1e999"
+                },
+                {
+                    "type": "script",
+                    "dest-filename": "processing.sh",
+                    "commands": [
+                        "#!/bin/sh",
+                        "exec /app/share/processing/processing $@"
+                    ]
                 }
             ]
         }

--- a/processing-add-appdata-tags.patch
+++ b/processing-add-appdata-tags.patch
@@ -1,30 +1,12 @@
 diff --git a/build/linux/appdata.xml b/build/linux/appdata.xml
-index f0fc87f9c..612d40d0e 100644
---- a/build/linux/appdata.xml
-+++ b/build/linux/appdata.xml
-@@ -2,7 +2,8 @@
- <!-- See https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html -->
- <component type="desktop-application">
-   <id>org.processing.processingide.desktop</id>
--  <metadata_license>GPLv3</metadata_license>
-+  <metadata_license>CC0-1.0</metadata_license>
-+  <project_license>GPL-2.0</project_license>
-   <developer_name>Processing Foundation</developer_name>
+--- a/build/linux/appdata.xml	2020-04-06 22:17:37.438680993 +0200
++++ b/build/linux/appdata.xml	2020-04-06 22:18:28.767254529 +0200
+@@ -32,6 +32,8 @@
+   <content_rating type="oars-1.1" />
  
-   <name>Processing IDE</name>
-@@ -28,6 +29,15 @@
-     </screenshot>
-   </screenshots>
- 
-+  <releases>
+   <releases>
 +    <release date="2020-01-17" version="3.5.4" />
 +    <release date="2019-02-03" version="3.5.3" />
-+    <release date="2018-07-26" version="3.4" />
-+    <release date="2018-07-22" version="3.3.7.2" />
-+    <release date="2018-07-01" version="3.3.7.1" />
-+    <release date="2018-03-13" version="3.3.7" />
-+  </releases>
-+
-   <url type="homepage">http://www.processing.org/</url>
-   <url type="help">https://processing.org/reference/</url>
-   <url type="bugtracker">https://github.com/processing/processing/issues?q=is%3Aopen</url>
+     <release date="2018-07-26" version="3.4" />
+     <release date="2018-07-22" version="3.3.7.2" />
+     <release date="2018-07-01" version="3.3.7.1" />

--- a/processing-add-appdata-tags.patch
+++ b/processing-add-appdata-tags.patch
@@ -12,13 +12,12 @@ index f0fc87f9c..612d40d0e 100644
    <developer_name>Processing Foundation</developer_name>
  
    <name>Processing IDE</name>
-@@ -28,6 +29,16 @@
+@@ -28,6 +29,15 @@
      </screenshot>
    </screenshots>
  
-+  <content_rating type="oars-1.1" />
-+
 +  <releases>
++    <release date="2020-01-17" version="3.5.4" />
 +    <release date="2019-02-03" version="3.5.3" />
 +    <release date="2018-07-26" version="3.4" />
 +    <release date="2018-07-22" version="3.3.7.2" />

--- a/processing-add-appdata-tags.patch
+++ b/processing-add-appdata-tags.patch
@@ -12,7 +12,7 @@ index f0fc87f9c..612d40d0e 100644
    <developer_name>Processing Foundation</developer_name>
  
    <name>Processing IDE</name>
-@@ -28,6 +29,15 @@
+@@ -28,6 +29,16 @@
      </screenshot>
    </screenshots>
  

--- a/processing-add-appdata-tags.patch
+++ b/processing-add-appdata-tags.patch
@@ -19,6 +19,7 @@ index f0fc87f9c..612d40d0e 100644
 +  <content_rating type="oars-1.1" />
 +
 +  <releases>
++    <release date="2019-02-03" version="3.5.3" />
 +    <release date="2018-07-26" version="3.4" />
 +    <release date="2018-07-22" version="3.3.7.2" />
 +    <release date="2018-07-01" version="3.3.7.1" />


### PR DESCRIPTION
Updates Processing to version 3.5.4, published on Jan 17, 2020.

This also changes the build process to download and install at build-time, pushing the whole package to `/app/share/processing` and creating a wrapper script that calls `/app/share/processing/processing` which is now left untouched.

Furthermore, this updates the runtime version to 19.08.