### PR TITLE
Update Processing to 4.2

### DIFF
--- a/org.processing.processingide.json
+++ b/org.processing.processingide.json
@@ -3,6 +3,7 @@
     "runtime": "org.freedesktop.Platform",
     "runtime-version": "22.08",
     "sdk": "org.freedesktop.Sdk",
+    "command": "processing",
     "build-options": {
         "cflags": "-O2 -g",
         "cxxflags": "-O2 -g",

--- a/org.processing.processingide.json
+++ b/org.processing.processingide.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.processing.processingide",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "21.08",
+    "runtime-version": "22.08",
     "sdk": "org.freedesktop.Sdk",
     "build-options": {
         "cflags": "-O2 -g",

--- a/org.processing.processingide.json
+++ b/org.processing.processingide.json
@@ -61,12 +61,12 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/processing/processing/releases/download/processing-0270-3.5.4/processing-3.5.4-linux64.tgz",
-                    "sha256": "ded445069db3c6fc384fe4da89ca7aa7d0a4bd2536c5aa8de3fa4e115de3025b"
+                    "url": "https://github.com/processing/processing4/releases/download/processing-1292-4.2/processing-4.2-linux-x64.tgz",
+                    "sha256": "8465313ef2e9bc566f248bc812691db73eadcff0b68a6e595eacaf68489282d7"
                 },
                 {
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/processing/processing/processing-0270-3.5.4/build/linux/appdata.xml",
+                    "url": "https://raw.githubusercontent.com/processing/processing4/processing-1292-4.2/build/linux/appdata.xml",
                     "sha256": "e6a142a75dece42fdee52cba1f9258f866bc95bc6318f04e92a92e1a301cac39"
                 },
                 {
@@ -76,7 +76,7 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/processing/processing/processing-0270-3.5.4/build/linux/processing-pde.xml",
+                    "url": "https://raw.githubusercontent.com/processing/processing4/processing-1292-4.2/build/linux/processing-pde.xml",
                     "sha256": "79e70baa8c1d81a60ac1bc59ea642bf80c638e5cb0ec7fe8372503bb8f2baa7f"
                 },
                 {
@@ -86,8 +86,8 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/processing/processing/processing-0270-3.5.4/build/linux/desktop.template",
-                    "sha256": "8a241bd3c41c52fb7a7ea4a67aa2657767e9c9e8a612dd5bca62866becdf873b"
+                    "url": "https://raw.githubusercontent.com/processing/processing4/processing-1292-4.2/build/linux/desktop.template",
+                    "sha256": "d34cfb197caaa8b9b30d0ed8dde210735e42a6fd4d481388df11c239770f6c44"
                 },
                 {
                     "type": "patch",
@@ -96,13 +96,13 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/processing/processing/processing-0270-3.5.4/build/shared/lib/icons/pde-64.png",
-                    "sha256": "feec5cf9be795d274296f39796b15994763f335be01c524b6216cf03de0a1b99"
+                    "url": "https://raw.githubusercontent.com/processing/processing4/processing-1292-4.2/build/shared/lib/icons/pde-64.png",
+                    "sha256": "d4a3619569e06f8ea8e7d8576a89b045c4e6bdc7623561ed086e1173e3a421b2"
                 },
                 {
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/processing/processing/processing-0270-3.5.4/build/shared/lib/icons/pde-128.png",
-                    "sha256": "1ee11856d783a44a5d4464206ae98d856dee837b9dc94ec5b06a4ca3b6f1e999"
+                    "url": "https://raw.githubusercontent.com/processing/processing4/processing-1292-4.2/build/shared/lib/icons/pde-128.png",
+                    "sha256": "2cab3cd180754f4210170182bb478cabf742b98a03a3a7f8942dc39bdf7555ba"
                 },
                 {
                     "type": "script",

--- a/org.processing.processingide.json
+++ b/org.processing.processingide.json
@@ -1,5 +1,5 @@
 {
-    "app-id": "org.processing.processingide",
+    "id": "org.processing.processingide",
     "runtime": "org.freedesktop.Platform",
     "runtime-version": "22.08",
     "sdk": "org.freedesktop.Sdk",

--- a/processing-add-appdata-tags.patch
+++ b/processing-add-appdata-tags.patch
@@ -1,7 +1,7 @@
 diff --git a/build/linux/appdata.xml b/build/linux/appdata.xml
 --- a/build/linux/appdata.xml	2020-04-06 22:17:37.438680993 +0200
 +++ b/build/linux/appdata.xml	2020-04-06 22:18:28.767254529 +0200
-@@ -32,6 +32,8 @@
+@@ -32,6 +32,18 @@
    <content_rating type="oars-1.1" />
  
    <releases>
@@ -15,6 +15,9 @@ diff --git a/build/linux/appdata.xml b/build/linux/appdata.xml
 +    <release date="2022-08-09" version="4.0" />
 +    <release date="2020-01-17" version="3.5.4" />
 +    <release date="2019-02-03" version="3.5.3" />
++    <release date="2019-01-22" version="3.5.2" />
++    <release date="2019-01-21" version="3.5.1" />
++    <release date="2019-01-20" version="3.5" />
      <release date="2018-07-26" version="3.4" />
      <release date="2018-07-22" version="3.3.7.2" />
      <release date="2018-07-01" version="3.3.7.1" />

--- a/processing-add-appdata-tags.patch
+++ b/processing-add-appdata-tags.patch
@@ -5,6 +5,14 @@ diff --git a/build/linux/appdata.xml b/build/linux/appdata.xml
    <content_rating type="oars-1.1" />
  
    <releases>
++    <release date="2023-02-20" version="4.2" />
++    <release date="2023-02-09" version="4.1.3" />
++    <release date="2023-01-16" version="4.1.2" />
++    <release date="2022-11-28" version="4.1.1" />
++    <release date="2022-11-28" version="4.1" />
++    <release date="2022-11-24" version="4.0.2" />
++    <release date="2022-08-09" version="4.0.1" />
++    <release date="2022-08-09" version="4.0" />
 +    <release date="2020-01-17" version="3.5.4" />
 +    <release date="2019-02-03" version="3.5.3" />
      <release date="2018-07-26" version="3.4" />

--- a/processing-add-appdata-tags.patch
+++ b/processing-add-appdata-tags.patch
@@ -1,7 +1,7 @@
 diff --git a/build/linux/appdata.xml b/build/linux/appdata.xml
 --- a/build/linux/appdata.xml	2020-04-06 22:17:37.438680993 +0200
 +++ b/build/linux/appdata.xml	2020-04-06 22:18:28.767254529 +0200
-@@ -32,6 +32,18 @@
+@@ -32,6 +32,19 @@
    <content_rating type="oars-1.1" />
  
    <releases>


### PR DESCRIPTION
I admittedly haven't used Processing before now, but by just opening up a sample project I was amazed at what can be done with it, and I'd definitely want to try it out more in the future. I decided to work on updating this Flatpak because, well, [let's just say an update has been long overdue](https://github.com/flathub/org.processing.processingide/issues/9).

This is my second time working with Flatpaks and Flathub like this (I updated the Godot Engine Flatpak to 4.0 a while back), so I hope I haven't botched it somehow. The built Flatpak seemed to run an example project well on my machine when I tested it, but then again, I used the x64 build of Processing for this Flatpak, so there's no knowing (for me, anyway) how the Flatpak will work on ARM-based machines (or if it'll work at all). I just thought I'd mention this [due to the contents of flathub.json](https://github.com/flathub/org.processing.processingide/blob/master/flathub.json), which, as of now, I didn't change.

Whatever happens, I do hope this much-needed update gets sorted out as soon as possible. I just thought I'd get it off to a much-needed start and then we'll see where things go.