### PR TITLE
Use provided app icons for Processing app in lieu of PDE file icons

### DIFF
--- a/org.processing.processingide.json
+++ b/org.processing.processingide.json
@@ -37,8 +37,8 @@
                 "install -D appdata.xml /app/share/metainfo/org.processing.processingide.appdata.xml",
                 "install -D desktop.template /app/share/applications/org.processing.processingide.desktop",
                 "install -D processing-pde.xml /app/share/mime/packages/org.processing.processingide.xml",
-                "install -D pde-64.png /app/share/icons/hicolor/64x64/apps/org.processing.processingide.png",
-                "install -D pde-128.png /app/share/icons/hicolor/128x128/apps/org.processing.processingide.png",
+                "install -D app-64.png /app/share/icons/hicolor/64x64/apps/org.processing.processingide.png",
+                "install -D app-128.png /app/share/icons/hicolor/128x128/apps/org.processing.processingide.png",
                 "install -D lib/desktop.template export/share/applications/org.processing.processingide.desktop",
                 "sed -i -e 's|<BINARY_LOCATION>|processing|' -e 's|<ICON_NAME>|org.processing.processingide|' export/share/applications/org.processing.processingide.desktop",
                 "sed -i -e 's|Programming;||' export/share/applications/org.processing.processingide.desktop",
@@ -97,13 +97,13 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/processing/processing4/processing-1293-4.3/build/shared/lib/icons/pde-64.png",
-                    "sha256": "6dd8f1727729f2b102692067c0806396666993e02fce809c04ddc24d0836c986"
+                    "url": "https://raw.githubusercontent.com/processing/processing4/processing-1293-4.3/build/shared/lib/icons/app-64.png",
+                    "sha256": "c1ec0cb93db6421d015d2f7f45eb50fe8da15050c9ee5d4e6456a216a972493f"
                 },
                 {
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/processing/processing4/processing-1293-4.3/build/shared/lib/icons/pde-128.png",
-                    "sha256": "c441588ff0e485ebae5d00c50bed640aec9a8fded79e9ebe49baf480c27a101d"
+                    "url": "https://raw.githubusercontent.com/processing/processing4/processing-1293-4.3/build/shared/lib/icons/app-128.png",
+                    "sha256": "a68754691f644b70df79c51fde902041fa90a983d34a90890bfe70e19ae8d3f3"
                 },
                 {
                     "type": "script",


### PR DESCRIPTION
Before:
![image](https://github.com/flathub/org.processing.processingide/assets/45298929/43e05c74-b3df-4923-b665-de4045a0f718)

After:
![image](https://github.com/flathub/org.processing.processingide/assets/45298929/2d167791-f02a-4eb5-a9ab-5e085f28311b)

The PDE file icons (such as pde-64.png) will still be used for PDE files, but not the main application itself (which was an oversight on my part while updating this Flatpak to 4.3 recently).