### PR TITLE
Partial fix for issues with running Processing's Python mode

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,3 @@
 {
-    "only-arches": ["x86_64", "arm"]
+    "only-arches": ["x86_64"]
 }

--- a/org.processing.processingide.json
+++ b/org.processing.processingide.json
@@ -33,6 +33,8 @@
             "build-commands": [
                 "install -d /app/share/processing",
                 "cp -r * /app/share/processing",
+                "mkdir /app/share/processing/natives",
+                "cp -r /app/share/processing/core/library/* /app/share/processing/natives",
                 "install -D processing.sh /app/bin/processing",
                 "install -D lib/appdata.xml /app/share/metainfo/org.processing.processingide.appdata.xml",
                 "install -D lib/desktop.template /app/share/applications/org.processing.processingide.desktop",

--- a/processing-update-appdata.patch
+++ b/processing-update-appdata.patch
@@ -1,7 +1,23 @@
 diff --git a/lib/appdata.xml b/lib/appdata.xml
 --- a/lib/appdata.xml	2020-04-06 22:17:37.438680993 +0200
 +++ b/lib/appdata.xml	2020-04-06 22:18:28.767254529 +0200
-@@ -24,14 +24,48 @@
+@@ -20,18 +20,64 @@
+       to develop interactive applications using different programming
+       languages but mainly Java, Android, Python, and Javascript.
+     </p>
++    <p>
++      Known issues:
++    </p>
++    <ul>
++      <li>
++        Python sketches can run but you may have trouble stopping them
++        running. If so, you will have to use your system monitor application
++        of choice (such as htop) to close the sketch, as it will be the
++        only way to stop the sketch, other than closing the IDE itself.
++        This problem also persists outside of Flatpak.
++      </li>
++    </ul>
+   </description>
  
    <screenshots>
      <screenshot type="default">
@@ -51,14 +67,18 @@ diff --git a/lib/appdata.xml b/lib/appdata.xml
      <release date="2018-07-26" version="3.4" />
      <release date="2018-07-22" version="3.3.7.2" />
      <release date="2018-07-01" version="3.3.7.1" />
-@@ -40,8 +74,8 @@
+@@ -40,9 +86,12 @@
  
    <url type="homepage">http://www.processing.org/</url>
    <url type="help">https://processing.org/reference/</url>
 -  <url type="bugtracker">https://github.com/processing/processing/issues?q=is%3Aopen</url>
 -  <url type="translate">https://github.com/processing/processing/tree/master/build/shared/lib/languages</url>
-+  <url type="bugtracker">https://github.com/processing/processing4/issues?q=is%3Aopen</url>
-+  <url type="translate">https://github.com/processing/processing4/tree/main/build/shared/lib/languages</url>
++  <url type="bugtracker">https://github.com/benfry/processing4/issues?q=is%3Aopen</url>
++  <url type="translate">https://github.com/benfry/processing4/tree/main/build/shared/lib/languages</url>
    <url type="donation">https://processing.org/download/support.html</url>
++  <url type="faq">https://github.com/benfry/processing4/wiki/FAQ</url>
++  <url type="vcs-browser">https://github.com/benfry/processing4/</url>
++  <url type="contribute">https://github.com/benfry/processing4/wiki</url>
  
    <update_contact>foundation@processing.org</update_contact>
+ </component>

--- a/processing-update-appdata.patch
+++ b/processing-update-appdata.patch
@@ -1,7 +1,7 @@
 diff --git a/lib/appdata.xml b/lib/appdata.xml
 --- a/lib/appdata.xml	2020-04-06 22:17:37.438680993 +0200
 +++ b/lib/appdata.xml	2020-04-06 22:18:28.767254529 +0200
-@@ -20,18 +20,64 @@
+@@ -20,18 +20,71 @@
        to develop interactive applications using different programming
        languages but mainly Java, Android, Python, and Javascript.
      </p>
@@ -15,6 +15,13 @@ diff --git a/lib/appdata.xml b/lib/appdata.xml
 +        of choice (such as htop) to close the sketch, as it will be the
 +        only way to stop the sketch, other than closing the IDE itself.
 +        This problem also persists outside of Flatpak.
++        See: https://github.com/flathub/org.processing.processingide/issues/5
++      </li>
++      <li>
++        When trying to open a Python sketch other than an example sketch in
++        the "Examples" dialog, the IDE may crash and close by itself. This
++        problem also persists outside of Flatpak.
++        See: https://github.com/benfry/processing4/issues/793
 +      </li>
 +    </ul>
    </description>
@@ -67,7 +74,7 @@ diff --git a/lib/appdata.xml b/lib/appdata.xml
      <release date="2018-07-26" version="3.4" />
      <release date="2018-07-22" version="3.3.7.2" />
      <release date="2018-07-01" version="3.3.7.1" />
-@@ -40,9 +86,12 @@
+@@ -40,9 +93,12 @@
  
    <url type="homepage">http://www.processing.org/</url>
    <url type="help">https://processing.org/reference/</url>


### PR DESCRIPTION
This should address, at least partially, the issue #5 in which Python sketches do not run.

The reason they do not run is because it is trying to find at least one library in a specific folder: `java.lang.UnsatisfiedLinkError: Can't load library: /app/share/processing/natives/linux-amd64/libgluegen_rt.so`

By creating the folder in the install and copying the relevant files from `core/library` in [the provided .tgz hosting the Processing binaries](https://github.com/processing/processing4/releases/download/processing-1293-4.3/processing-4.3-linux-x64.tgz), the library can be found and the sketch will run.

However, I run into problems when trying to **stop** the sketch. While the IDE itself is still responsive, the sketch preview freezes and generates this error:
```
Exception in thread "processing.py mode runner" java.lang.NoClassDefFoundError: processing/javafx/PSurfaceFX
	at jycessing.PAppletJythonDriver.runAndBlock(PAppletJythonDriver.java:952)
	at jycessing.Runner.runSketchBlocking(Runner.java:409)
	at jycessing.mode.run.SketchRunner.lambda$2(SketchRunner.java:112)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.lang.ClassNotFoundException: processing.javafx.PSurfaceFX
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
	... 4 more
```

The only way to close the sketch without closing the IDE is by somehow manually killing the process occupied by the open sketch window, using a system monitor application such as top, htop or the one your Linux distribution and/or desktop environment provides.

Therefore, it may not be a **complete** fix, but it's a _start_, and at least Python sketches can somewhat _run_ now. Hopefully in the future, there will a solution to the above errors caused when trying to _stop_ Python sketches in the IDE.